### PR TITLE
puppet:wireguard: set default for `$source_addresses` to `[]`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -135,11 +135,11 @@ Default value: `Integer(regsubst($title, '^\D+(\d+)$', '\1'))`
 
 ##### <a name="source_addresses"></a>`source_addresses`
 
-Data type: `Optional[Array[Stdlib::IP::Address]]`
+Data type: `Array[Stdlib::IP::Address]`
 
 an array of ip addresses from where we receive wireguard connections
 
-Default value: ``undef``
+Default value: `[]`
 
 ##### <a name="destination_addresses"></a>`destination_addresses`
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -38,7 +38,7 @@ define wireguard::interface (
   Integer[1024, 65000] $dport = Integer(regsubst($title, '^\D+(\d+)$', '\1')),
   Optional[String[1]] $input_interface = undef,
   Boolean $manage_firewall = true,
-  Optional[Array[Stdlib::IP::Address]] $source_addresses = undef,
+  Array[Stdlib::IP::Address] $source_addresses = [],
   Array[Hash[String,Variant[Stdlib::IP::Address::V4::CIDR,Stdlib::IP::Address::V6::CIDR]]] $addresses = [],
 ) {
   require wireguard


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
