### PR TITLE
wireguard:interface: default `input_interface` to `networking.primary` fact

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -111,11 +111,11 @@ Default value: `$title`
 
 ##### <a name="input_interface"></a>`input_interface`
 
-Data type: `Optional[String[1]]`
+Data type: `String[1]`
 
 ethernet interface where the wireguard packages will enter the system, used for firewall rules
 
-Default value: ``undef``
+Default value: `$facts['networking']['primary']`
 
 ##### <a name="manage_firewall"></a>`manage_firewall`
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -36,7 +36,7 @@ define wireguard::interface (
   Optional[Array[Stdlib::IP::Address]] $destination_addresses = [$facts['networking']['ip'], $facts['networking']['ip6'],],
   String[1] $interface = $title,
   Integer[1024, 65000] $dport = Integer(regsubst($title, '^\D+(\d+)$', '\1')),
-  Optional[String[1]] $input_interface = undef,
+  String[1] $input_interface = $facts['networking']['primary'],
   Boolean $manage_firewall = true,
   Array[Stdlib::IP::Address] $source_addresses = [],
   Array[Hash[String,Variant[Stdlib::IP::Address::V4::CIDR,Stdlib::IP::Address::V6::CIDR]]] $addresses = [],


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
