### PR TITLE
Make endpoint parameter optional

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -85,6 +85,14 @@ wireguard::interface {'as2273':
   endpoint         => 'wg.example.com:53668',
   addresses        => [{'Address' => '192.168.218.87/32', 'Peer' => '172.20.53.97/32'}, {'Address' => 'fe80::ade1/64',},],
 }
+
+Create a passive wireguard interface that listens for incoming connections. Useful when the other side has a dynamic IP / is behind NAT
+wireguard::interface {'as2273':
+  source_addresses => ['2003:4f8:c17:4cf::1', '149.9.255.4'],
+  public_key       => 'BcxLll1BVxGQ5DeijroesjroiesjrjvX+EBhS4vcDn0R0=',
+  dport            => 53668,
+  addresses        => [{'Address' => '192.168.218.87/32', 'Peer' => '172.20.53.97/32'}, {'Address' => 'fe80::ade1/64',},],
+}
 ```
 
 #### Parameters
@@ -143,7 +151,7 @@ Default value: `[]`
 
 ##### <a name="destination_addresses"></a>`destination_addresses`
 
-Data type: `Optional[Array[Stdlib::IP::Address]]`
+Data type: `Array[Stdlib::IP::Address]`
 
 array of addresses where the remote peer connects to (our local ips), used for firewalling
 
@@ -157,9 +165,11 @@ base64 encoded pubkey from the remote peer
 
 ##### <a name="endpoint"></a>`endpoint`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 fqdn:port or ip:port where we connect to
+
+Default value: ``undef``
 
 ##### <a name="addresses"></a>`addresses`
 


### PR DESCRIPTION
The endpoint parameter is only required if wireguard should connect to a
remote site. That's not always possible. For example in situations where
the remote site is behind a NAT gateway and/or has a dynamic IP address.
For such setups you can create a 'passive' configuration that listens
for incoming packets.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
