### PR TITLE
Make filtering on dest addr optional

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -55,6 +55,10 @@ define wireguard::interface (
   require wireguard
 
   if $manage_firewall {
+    $daddr = empty($destination_addresses) ? {
+      true    => undef,
+      default => $destination_addresses,
+    }
     ferm::rule { "allow_wg_${interface}":
       action    => 'ACCEPT',
       chain     => 'INPUT',
@@ -62,7 +66,7 @@ define wireguard::interface (
       dport     => $dport,
       interface => $input_interface,
       saddr     => $source_addresses,
-      daddr     => $destination_addresses,
+      daddr     => $daddr,
       notify    => Service['systemd-networkd'],
     }
   }

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -96,6 +96,28 @@ describe 'wireguard::interface', type: :define do
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").with_content(%r{Address=fe80::ade1/64}) }
         it { is_expected.not_to contain_ferm__rule("allow_wg_#{title}") }
       end
+      context 'with empty destintion_addresses' do
+        let :pre_condition do
+          'class{"ferm":
+          configfile => "/etc/ferm.conf",
+          configdirectory => "/etc/ferm.d/"
+          }
+          class {"systemd":
+            manage_networkd => true
+          }'
+        end
+        let :params do
+          {
+            public_key: 'blabla==',
+            endpoint: 'wireguard.example.com:1234',
+            manage_firewall: true,
+            destination_addresses: [],
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_ferm__rule("allow_wg_#{title}").without_daddr }
+      end
     end
   end
 end


### PR DESCRIPTION
Previously `$destination_addresses` was an array with the public
ipv6/ipv4 addresses. Those were used as destination address in the
firewall rules. People might have dynamic local ips so this won't
work/creates a lot of noise due to constant firewall rule updates. As a
fix, it was already possible to set `$destination_addresses` to an empty
Array (`[]`). But passing this to the `daddr` parameter in ferm::rule
created a broken firewall rule. This patch sets the `daddr` parameter to
`undef` if `$destination_addresses` is an empty array.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
