### PR TITLE
fact: support keyfiles with multiple dots

### DIFF
--- a/lib/facter/wireguard_pubkeys.rb
+++ b/lib/facter/wireguard_pubkeys.rb
@@ -5,7 +5,7 @@ Facter.add(:wireguard_pubkeys) do
   setcode do
     hash = {}
     Dir.glob('/etc/wireguard/*.pub').each do |file|
-      filename = file.split('/')[3].split('.')[0]
+      filename = file.split('/').last.gsub('.pub', '')
       content = File.read(file)
       hash[filename] = content.chomp
     end


### PR DESCRIPTION
Previously we assumed that the path to a key always contains an exact
amount of slashes and the filename only a single dot. Although the path
is still hardcoded, we now select the filename from the path and trim
the last `.pub`. People can now use multiple dots in their key names.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
