### PR TITLE
Add possibility to add multiple peers

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -12,6 +12,10 @@
 
 * [`wireguard::interface`](#wireguardinterface): manages a wireguard setup
 
+### Data types
+
+* [`Wireguard::Peers`](#wireguardpeers): custom data type for an array with wireguard peers
+
 ## Classes
 
 ### <a name="wireguard"></a>`wireguard`
@@ -127,6 +131,25 @@ wireguard::interface {'as3668-2':
   mtu                   => 1412,
 ```
 
+##### create a wireguard interface with multiple peers
+
+```puppet
+wireguard::interface { 'wg0':
+  dport     => 1338,
+  addresses => [{'Address' => '192.0.2.1/24'}],
+  peers     => [
+    {
+       public_key  => 'foo==',
+       allowed_ips => ['192.0.2.2'],
+    },
+    {
+       public_key  => 'bar==',
+       allowed_ips => ['192.0.2.3'],
+    }
+  ],
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `wireguard::interface` defined type:
@@ -143,6 +166,7 @@ The following parameters are available in the `wireguard::interface` defined typ
 * [`persistent_keepalive`](#persistent_keepalive)
 * [`description`](#description)
 * [`mtu`](#mtu)
+* [`peers`](#peers)
 
 ##### <a name="interface"></a>`interface`
 
@@ -194,9 +218,11 @@ Default value: `[$facts['networking']['ip'], $facts['networking']['ip6'],]`
 
 ##### <a name="public_key"></a>`public_key`
 
-Data type: `String[1]`
+Data type: `Optional[String[1]]`
 
 base64 encoded pubkey from the remote peer
+
+Default value: ``undef``
 
 ##### <a name="endpoint"></a>`endpoint`
 
@@ -237,4 +263,32 @@ Data type: `Optional[Integer[1280, 9000]]`
 configure the MTU (maximum transision unit) for the wireguard tunnel. By default linux will figure this out. You might need to lower it if you're connection through a DSL line. MTU needs to be equal on both tunnel endpoints
 
 Default value: ``undef``
+
+##### <a name="peers"></a>`peers`
+
+Data type: `Wireguard::Peers`
+
+is an array of struct (Wireguard::Peers) for multiple peers
+
+Default value: `[]`
+
+## Data types
+
+### <a name="wireguardpeers"></a>`Wireguard::Peers`
+
+custom data type for an array with wireguard peers
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.netdev.html#%5BWireGuardPeer%5D%20Section%20Options
+
+Alias of
+
+```puppet
+Array[Struct[{
+    public_key           => String[1],
+    allowed_ips          => Optional[Array[String[1]]],
+    endpoint             => Optional[String[1]],
+    persistent_keepalive => Optional[Stdlib::Port],
+  }]]
+```
 

--- a/spec/fixtures/test_files/peers.netdev
+++ b/spec/fixtures/test_files/peers.netdev
@@ -1,0 +1,22 @@
+# THIS FILE IS MANAGED BY PUPPET
+# based on https://dn42.dev/howto/wireguard
+[NetDev]
+Name=as1234
+Kind=wireguard
+
+[WireGuard]
+PrivateKeyFile=/etc/wireguard/as1234
+ListenPort=1234
+
+[WireGuardPeer]
+PublicKey=blabla==
+Endpoint=wireguard.example.com:1234
+PersistentKeepalive=0
+AllowedIPs=fe80::/64
+AllowedIPs=fd00::/8
+AllowedIPs=0.0.0.0/0
+
+[WireGuardPeer]
+PublicKey=foo==
+PersistentKeepalive=0
+AllowedIPs=192.0.2.3

--- a/spec/fixtures/test_files/peers.network
+++ b/spec/fixtures/test_files/peers.network
@@ -1,0 +1,17 @@
+# THIS FILE IS MANAGED BY PUPPET
+# based on https://dn42.dev/howto/wireguard
+[Match]
+Name=as1234
+
+[Network]
+DHCP=no
+IPv6AcceptRA=false
+IPForward=yes
+
+# for networkd >= 244 KeepConfiguration stops networkd from
+# removing routes on this interface when restarting
+KeepConfiguration=yes
+
+[Address]
+Address=192.0.2.1/24
+

--- a/templates/netdev.epp
+++ b/templates/netdev.epp
@@ -1,0 +1,33 @@
+<%- | String[1] $interface,
+      Stdlib::Port $dport,
+      Wireguard::Peers $peers,
+      Optional[String] $description,
+      Optional[Integer] $mtu,
+| -%>
+# THIS FILE IS MANAGED BY PUPPET
+# based on https://dn42.dev/howto/wireguard
+[NetDev]
+Name=<%= $interface %>
+Kind=wireguard
+<% if $description { -%>
+Description=<%= $description %>
+<% } -%>
+<% if $mtu { -%>
+MTUBytes=<%= $mtu %>
+<% } -%>
+
+[WireGuard]
+PrivateKeyFile=/etc/wireguard/<%= $interface %>
+ListenPort=<%= $dport %>
+<% $peers.each |$peer| { -%>
+
+[WireGuardPeer]
+PublicKey=<%= $peer['public_key'] %>
+<% if $peer['endpoint'] { -%>
+Endpoint=<%= $peer['endpoint'] %>
+<% } -%>
+PersistentKeepalive=<%= pick($peer['persistent_keepalive'], 0) %>
+<% pick($peer['allowed_ips'], ['fe80::/64', 'fd00::/8', '0.0.0.0/0']).each |$allowed_ip| { -%>
+AllowedIPs=<%= $allowed_ip %>
+<% } -%>
+<% } -%>

--- a/templates/network.epp
+++ b/templates/network.epp
@@ -1,0 +1,25 @@
+<%- |
+    Array[Hash] $addresses,
+    String[1] $interface,
+| -%>
+# THIS FILE IS MANAGED BY PUPPET
+# based on https://dn42.dev/howto/wireguard
+[Match]
+Name=<%= $interface %>
+
+[Network]
+DHCP=no
+IPv6AcceptRA=false
+IPForward=yes
+
+# for networkd >= 244 KeepConfiguration stops networkd from
+# removing routes on this interface when restarting
+KeepConfiguration=yes
+<% $addresses.each |$address| { -%>
+
+[Address]
+<% $address.each |$key, $value| { -%>
+<%= $key %>=<%= $value %>
+<% } -%>
+<% } -%>
+

--- a/types/peers.pp
+++ b/types/peers.pp
@@ -1,0 +1,14 @@
+# @summary custom data type for an array with wireguard peers
+#
+# @author Tim Meusel <tim@bastelfreak.de>
+# @author Sebastian Rakel <sebastian@devunit.eu>
+#
+# @see https://www.freedesktop.org/software/systemd/man/systemd.netdev.html#%5BWireGuardPeer%5D%20Section%20Options
+type Wireguard::Peers = Array[
+  Struct[{
+    public_key           => String[1],
+    allowed_ips          => Optional[Array[String[1]]],
+    endpoint             => Optional[String[1]],
+    persistent_keepalive => Optional[Stdlib::Port],
+  }]
+]


### PR DESCRIPTION
The current version of this module only supports one peer per
wireguard interface.
But the systemd-networkd wireguard implementation allows multiple
WireguardPeer sections.

This PR implement this function with backward compatbility
