### PR TITLE
Add description to peers

### DIFF
--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -54,6 +54,7 @@ describe 'wireguard::interface', type: :define do
               },
               {
                 public_key: 'foo==',
+                description: 'foo',
                 allowed_ips: ['192.0.2.3'],
               }
             ],
@@ -244,6 +245,7 @@ describe 'wireguard::interface', type: :define do
               },
               {
                 public_key: 'foo==',
+                description: 'foo',
                 allowed_ips: ['192.0.2.3'],
               }
             ],

--- a/spec/fixtures/test_files/peers.netdev
+++ b/spec/fixtures/test_files/peers.netdev
@@ -17,6 +17,7 @@ AllowedIPs=fd00::/8
 AllowedIPs=0.0.0.0/0
 
 [WireGuardPeer]
+Description=foo
 PublicKey=foo==
 PersistentKeepalive=0
 AllowedIPs=192.0.2.3

--- a/templates/netdev.epp
+++ b/templates/netdev.epp
@@ -22,6 +22,9 @@ ListenPort=<%= $dport %>
 <% $peers.each |$peer| { -%>
 
 [WireGuardPeer]
+<% if $peer['description'] { -%>
+Description=<%= $peer['description'] %>
+<% } -%>
 PublicKey=<%= $peer['public_key'] %>
 <% if $peer['endpoint'] { -%>
 Endpoint=<%= $peer['endpoint'] %>

--- a/types/peers.pp
+++ b/types/peers.pp
@@ -10,5 +10,6 @@ type Wireguard::Peers = Array[
     allowed_ips          => Optional[Array[String[1]]],
     endpoint             => Optional[String[1]],
     persistent_keepalive => Optional[Stdlib::Port],
+    description          => Optional[String[1]],
   }]
 ]


### PR DESCRIPTION
this adds a description option to peers, if there a more than one peer
its hard to recognize the peer by reading the config. there a a lot
peers only identfied by a public key and a address, so maybe for
someone its helpful to write the hostname or some other description as
comment over the peer block
