### PR TITLE
Allow usage of pre-shared keys on interfaces

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -16,6 +16,7 @@
 # @param peers is an array of struct (Wireguard::Peers) for multiple peers
 # @param routes different routes for the systemd-networkd configuration
 # @param private_key Define private key which should be used for this interface, if not provided a private key will be generated
+# @param preshared_key Define preshared key which should be used for this interface
 #
 # @author Tim Meusel <tim@bastelfreak.de>
 # @author Sebastian Rakel <sebastian@devunit.eu>
@@ -50,6 +51,7 @@
 #  wireguard::interface {'as3668-2':
 #    source_addresses      => ['144.76.249.220', '2a01:4f8:171:1152::12'],
 #    public_key            => 'Tci/bHoPCjTpYv8bw17xQ7P4OdqzGpEN+NDueNjUvBA=',
+#    preshared_key         => '/22q9I+RpWRsU+zshW8skv1p00TvnEE6fTvPJuI2Cp4=',
 #    endpoint              => 'router02.bastelfreak.org:1338',
 #    dport                 => 1338,
 #    input_interface       => $facts['networking']['primary'],
@@ -91,6 +93,7 @@ define wireguard::interface (
   Optional[String[1]] $public_key = undef,
   Array[Hash[String[1], Variant[String[1], Boolean]]] $routes = [],
   Optional[String[1]] $private_key = undef,
+  Optional[String[1]] $preshared_key = undef,
 ) {
   require wireguard
 
@@ -170,11 +173,12 @@ define wireguard::interface (
 
   systemd::network { "${interface}.netdev":
     content         => epp("${module_name}/netdev.epp", {
-        'interface'   => $interface,
-        'dport'       => $dport,
-        'description' => $description,
-        'mtu'         => $mtu,
-        'peers'       => $peers + $peer,
+        'interface'     => $interface,
+        'dport'         => $dport,
+        'description'   => $description,
+        'preshared_key' => $preshared_key,
+        'mtu'           => $mtu,
+        'peers'         => $peers + $peer,
     }),
     restart_service => true,
     owner           => 'root',

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -122,7 +122,7 @@ describe 'wireguard::interface', type: :define do
         it { is_expected.to contain_ferm__rule("allow_wg_#{title}") }
       end
 
-      context 'with required params and without firewall rules and with configured addresses' do
+      context 'with required params and without firewall rules and with configured addresses and with preshared key' do
         let :params do
           {
             public_key: 'blabla==',
@@ -132,6 +132,7 @@ describe 'wireguard::interface', type: :define do
             # that would configure IPv4+IPv6, but GHA doesn't provide IPv6 for us
             destination_addresses: [facts[:networking]['ip'],],
             addresses: [{ 'Address' => '192.168.218.87/32', 'Peer' => '172.20.53.97/32' }, { 'Address' => 'fe80::ade1/64', },],
+            preshared_key: 'mypsk==',
           }
         end
 
@@ -147,6 +148,7 @@ describe 'wireguard::interface', type: :define do
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").with_content(%r{Address=192.168.218.87/32}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").with_content(%r{Peer=172.20.53.97/32}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").with_content(%r{Address=fe80::ade1/64}) }
+        it { is_expected.to contain_file("/etc/systemd/network/#{title}.netdev").with_content(%r{PresharedKey=mypsk==}) }
         it { is_expected.not_to contain_ferm__rule("allow_wg_#{title}") }
       end
 

--- a/templates/netdev.epp
+++ b/templates/netdev.epp
@@ -3,6 +3,7 @@
       Wireguard::Peers $peers,
       Optional[String] $description,
       Optional[Integer] $mtu,
+      Optional[String[1]] $preshared_key,
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
 # based on https://dn42.dev/howto/wireguard
@@ -26,6 +27,9 @@ ListenPort=<%= $dport %>
 Description=<%= $peer['description'] %>
 <% } -%>
 PublicKey=<%= $peer['public_key'] %>
+<% if $preshared_key { -%>
+PresharedKey=<%= $preshared_key %>
+<% } -%>
 <% if $peer['endpoint'] { -%>
 Endpoint=<%= $peer['endpoint'] %>
 <% } -%>


### PR DESCRIPTION
New PR to incorporate changes for PR #47. Attribution of the original author is done by using `Co-authored-by` 😊

#### Pull Request (PR) description
WireGuard offers the option to use pre-shared keys per interface. While this option is not required to use WireGuard, if the other party uses pre-shared keys, the connecting client is forced to use this pre-shared key as well.

#### This Pull Request (PR) fixes the following issues
Fixes #46
