### PR TITLE
Move preshared_key from interface to peer configuration

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -16,7 +16,6 @@
 # @param peers is an array of struct (Wireguard::Peers) for multiple peers
 # @param routes different routes for the systemd-networkd configuration
 # @param private_key Define private key which should be used for this interface, if not provided a private key will be generated
-# @param preshared_key Define preshared key which should be used for this interface
 #
 # @author Tim Meusel <tim@bastelfreak.de>
 # @author Sebastian Rakel <sebastian@devunit.eu>
@@ -51,7 +50,6 @@
 #  wireguard::interface {'as3668-2':
 #    source_addresses      => ['144.76.249.220', '2a01:4f8:171:1152::12'],
 #    public_key            => 'Tci/bHoPCjTpYv8bw17xQ7P4OdqzGpEN+NDueNjUvBA=',
-#    preshared_key         => '/22q9I+RpWRsU+zshW8skv1p00TvnEE6fTvPJuI2Cp4=',
 #    endpoint              => 'router02.bastelfreak.org:1338',
 #    dport                 => 1338,
 #    input_interface       => $facts['networking']['primary'],
@@ -61,13 +59,14 @@
 #    mtu                   => 1412,
 # }
 #
-# @example create a wireguard interface with multiple peers
+# @example create a wireguard interface with multiple peers where one uses a preshared key
 #  wireguard::interface { 'wg0':
 #    dport     => 1338,
 #    addresses => [{'Address' => '192.0.2.1/24'}],
 #    peers     => [
 #      {
 #         public_key  => 'foo==',
+#         preshared_key => '/22q9I+RpWRsU+zshW8skv1p00TvnEE6fTvPJuI2Cp4=',
 #         allowed_ips => ['192.0.2.2'],
 #      },
 #      {
@@ -93,7 +92,6 @@ define wireguard::interface (
   Optional[String[1]] $public_key = undef,
   Array[Hash[String[1], Variant[String[1], Boolean]]] $routes = [],
   Optional[String[1]] $private_key = undef,
-  Optional[String[1]] $preshared_key = undef,
 ) {
   require wireguard
 
@@ -173,12 +171,11 @@ define wireguard::interface (
 
   systemd::network { "${interface}.netdev":
     content         => epp("${module_name}/netdev.epp", {
-        'interface'     => $interface,
-        'dport'         => $dport,
-        'description'   => $description,
-        'preshared_key' => $preshared_key,
-        'mtu'           => $mtu,
-        'peers'         => $peers + $peer,
+        'interface'   => $interface,
+        'dport'       => $dport,
+        'description' => $description,
+        'mtu'         => $mtu,
+        'peers'       => $peers + $peer,
     }),
     restart_service => true,
     owner           => 'root',

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -16,6 +16,7 @@
 # @param peers is an array of struct (Wireguard::Peers) for multiple peers
 # @param routes different routes for the systemd-networkd configuration
 # @param private_key Define private key which should be used for this interface, if not provided a private key will be generated
+# @param preshared_key Define preshared key for the remote peer
 #
 # @author Tim Meusel <tim@bastelfreak.de>
 # @author Sebastian Rakel <sebastian@devunit.eu>
@@ -92,6 +93,7 @@ define wireguard::interface (
   Optional[String[1]] $public_key = undef,
   Array[Hash[String[1], Variant[String[1], Boolean]]] $routes = [],
   Optional[String[1]] $private_key = undef,
+  Optional[String[1]] $preshared_key = undef,
 ) {
   require wireguard
 
@@ -162,8 +164,9 @@ define wireguard::interface (
 
   if $public_key {
     $peer = [{
-        public_key => $public_key,
-        endpoint   => $endpoint,
+        public_key    => $public_key,
+        endpoint      => $endpoint,
+        preshared_key => $preshared_key,
     }]
   } else {
     $peer = []

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -55,6 +55,7 @@ describe 'wireguard::interface', type: :define do
               },
               {
                 public_key: 'foo==',
+                preshared_key: 'bar=',
                 description: 'foo',
                 allowed_ips: ['192.0.2.3'],
               }
@@ -122,7 +123,7 @@ describe 'wireguard::interface', type: :define do
         it { is_expected.to contain_ferm__rule("allow_wg_#{title}") }
       end
 
-      context 'with required params and without firewall rules and with configured addresses and with preshared key' do
+      context 'with required params and without firewall rules and with configured addresses' do
         let :params do
           {
             public_key: 'blabla==',
@@ -132,7 +133,6 @@ describe 'wireguard::interface', type: :define do
             # that would configure IPv4+IPv6, but GHA doesn't provide IPv6 for us
             destination_addresses: [facts[:networking]['ip'],],
             addresses: [{ 'Address' => '192.168.218.87/32', 'Peer' => '172.20.53.97/32' }, { 'Address' => 'fe80::ade1/64', },],
-            preshared_key: 'mypsk==',
           }
         end
 
@@ -148,7 +148,6 @@ describe 'wireguard::interface', type: :define do
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").with_content(%r{Address=192.168.218.87/32}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").with_content(%r{Peer=172.20.53.97/32}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").with_content(%r{Address=fe80::ade1/64}) }
-        it { is_expected.to contain_file("/etc/systemd/network/#{title}.netdev").with_content(%r{PresharedKey=mypsk==}) }
         it { is_expected.not_to contain_ferm__rule("allow_wg_#{title}") }
       end
 
@@ -251,6 +250,7 @@ describe 'wireguard::interface', type: :define do
               },
               {
                 public_key: 'foo==',
+                preshared_key: 'bar=',
                 description: 'foo',
                 allowed_ips: ['192.0.2.3'],
               }

--- a/spec/fixtures/test_files/peers.netdev
+++ b/spec/fixtures/test_files/peers.netdev
@@ -19,5 +19,6 @@ AllowedIPs=0.0.0.0/0
 [WireGuardPeer]
 Description=foo
 PublicKey=foo==
+PresharedKey=bar=
 PersistentKeepalive=0
 AllowedIPs=192.0.2.3

--- a/templates/netdev.epp
+++ b/templates/netdev.epp
@@ -3,7 +3,6 @@
       Wireguard::Peers $peers,
       Optional[String] $description,
       Optional[Integer] $mtu,
-      Optional[String[1]] $preshared_key,
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
 # based on https://dn42.dev/howto/wireguard
@@ -27,8 +26,8 @@ ListenPort=<%= $dport %>
 Description=<%= $peer['description'] %>
 <% } -%>
 PublicKey=<%= $peer['public_key'] %>
-<% if $preshared_key { -%>
-PresharedKey=<%= $preshared_key %>
+<% if $peer['preshared_key'] { -%>
+PresharedKey=<%= $peer['preshared_key'] %>
 <% } -%>
 <% if $peer['endpoint'] { -%>
 Endpoint=<%= $peer['endpoint'] %>

--- a/types/peers.pp
+++ b/types/peers.pp
@@ -7,6 +7,7 @@
 type Wireguard::Peers = Array[
   Struct[{
     public_key           => String[1],
+    preshared_key        => Optional[String[1]],
     allowed_ips          => Optional[Array[String[1]]],
     endpoint             => Optional[String[1]],
     persistent_keepalive => Optional[Stdlib::Port],


### PR DESCRIPTION
`PresharedKey` is a per-peer configuration and should be handled as such. This enables one to set a different preshared key per peer.