### PR TITLE
Throw warning instead of fail if peers is empty 

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -102,7 +102,7 @@ define wireguard::interface (
   require wireguard
 
   if empty($peers) and !$public_key {
-    fail('peers or public_key have to been set')
+    warning('peers or public_key have to been set')
   }
 
   if $manage_firewall {


### PR DESCRIPTION
If you build a wireguard network, based on puppetdb queries. it's possible that there no peers, because they didn't sent there facts at this point.

now the puppet agent will cancel, cause there are no peers.

so my tought is, a warning instead of fail should be enough