### PR TITLE
Workaround for missing ipv6 addresses

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -244,7 +244,7 @@ Data type: `Array[Stdlib::IP::Address]`
 
 array of addresses where the remote peer connects to (our local ips), used for firewalling
 
-Default value: `[$facts['networking']['ip'], $facts['networking']['ip6'],]`
+Default value: `delete_undef_values([$facts['networking']['ip'], $facts['networking']['ip6'],])`
 
 ##### <a name="public_key"></a>`public_key`
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -84,7 +84,7 @@ define wireguard::interface (
   Wireguard::Peers $peers = [],
   Optional[String[1]] $endpoint = undef,
   Integer[0, 65535] $persistent_keepalive = 0,
-  Array[Stdlib::IP::Address] $destination_addresses = [$facts['networking']['ip'], $facts['networking']['ip6'],],
+  Array[Stdlib::IP::Address] $destination_addresses = delete_undef_values([$facts['networking']['ip'], $facts['networking']['ip6'],]),
   String[1] $interface = $title,
   Integer[1024, 65000] $dport = Integer(regsubst($title, '^\D+(\d+)$', '\1')),
   String[1] $input_interface = $facts['networking']['primary'],


### PR DESCRIPTION
in case `$facts['networking']['ip6']` is empty it returns undef. we need
to filter this out because the ferm module has a strict type and doesn't
allow it.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
