### PR TITLE
Fix $addresses hash needs to accept any type of v4 or v6 address

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -90,7 +90,7 @@ define wireguard::interface (
   String[1] $input_interface = $facts['networking']['primary'],
   Boolean $manage_firewall = true,
   Array[Stdlib::IP::Address] $source_addresses = [],
-  Array[Hash[String,Variant[Stdlib::IP::Address::V4::CIDR,Stdlib::IP::Address::V6::CIDR]]] $addresses = [],
+  Array[Hash[String,Variant[Stdlib::IP::Address::V4,Stdlib::IP::Address::V6]]] $addresses = [],
   Optional[String[1]] $description = undef,
   Optional[Integer[1280, 9000]] $mtu = undef,
   Optional[String[1]] $public_key = undef,

--- a/manifests/provider/systemd.pp
+++ b/manifests/provider/systemd.pp
@@ -6,7 +6,7 @@ define wireguard::provider::systemd (
   Enum['present', 'absent'] $ensure = 'present',
   Wireguard::Peers $peers = [],
   Integer[1024, 65000] $dport = Integer(regsubst($title, '^\D+(\d+)$', '\1')),
-  Array[Hash[String,Variant[Stdlib::IP::Address::V4::CIDR,Stdlib::IP::Address::V6::CIDR]]] $addresses = [],
+  Array[Hash[String,Variant[Stdlib::IP::Address::V4,Stdlib::IP::Address::V6]]] $addresses = [],
   Optional[String[1]] $description = undef,
   Optional[Integer[1280, 9000]] $mtu = undef,
   Array[Hash[String[1], Variant[String[1], Boolean]]] $routes = [],

--- a/manifests/provider/wgquick.pp
+++ b/manifests/provider/wgquick.pp
@@ -6,7 +6,7 @@ define wireguard::provider::wgquick (
   Enum['present', 'absent'] $ensure = 'present',
   Wireguard::Peers $peers = [],
   Integer[1024, 65000] $dport = Integer(regsubst($title, '^\D+(\d+)$', '\1')),
-  Array[Hash[String,Variant[Stdlib::IP::Address::V4::CIDR,Stdlib::IP::Address::V6::CIDR]]] $addresses = [],
+  Array[Hash[String,Variant[Stdlib::IP::Address::V4,Stdlib::IP::Address::V6]]] $addresses = [],
 ) {
   assert_private()
   $params = {

--- a/templates/wireguard_conf.epp
+++ b/templates/wireguard_conf.epp
@@ -7,7 +7,7 @@
 # THIS FILE IS MANAGED BY PUPPET
 [Interface]
 <% $addresses.each |$address| { -%>
-Address = <%= $address['Address'] %>
+<%= $key %>=<%= $value %>
 <% } -%>
 ListenPort = <%= $dport %>
 PostUp = wg set %i private-key /etc/wireguard/<%= $interface %>


### PR DESCRIPTION
we are using the $address parameter for the address block in wireguard
config.
this blocks also allows thinks like DNS and dns don't need to be a
CIDR.

This commit will change this and accept a address or a CIDR address
