### PR TITLE
add examples, document systemd-networkd and wg-quick

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ wireguard::interface {'as1234':
 }
 ````
 
+More examples are available in the [REFERENCE.md](./REFERENCE.md) file.
+
 ## Parameter reference
 
 All parameters are documented with puppet-strings. You can view the

--- a/README.md
+++ b/README.md
@@ -25,10 +25,13 @@ This is enabled by default but can be disabled by setting the `manage_firewall`
 parameter to false in the `wireguard::interface` defined resource. You need to
 have the `ferm` class in your catalog to use the feature.
 
-This module uses [systemd-networkd](https://www.freedesktop.org/software/systemd/man/systemd-networkd.html).
-You need to have a systemd-networkd service resource in your catalog. We recommend
-[voxpupuli/systemd](https://github.com/voxpupuli/puppet-systemd#systemd) with
-`manage_networkd` set to true.
+This module can uses [systemd-networkd](https://www.freedesktop.org/software/systemd/man/systemd-networkd.html) or [wg-quick](https://manpages.debian.org/wg-quick) to
+configure tunnels. For the former, you need to have a systemd-networkd
+service resource in your catalog. We recommend [voxpupuli/systemd](https://github.com/voxpupuli/puppet-systemd#systemd)
+with `manage_networkd` set to true. You do not need to configure your
+entire network with `systemd-networkd`, only the tunnels. That said,
+`wg-quick` might be better a better match if you do not want to touch
+`systemd`.
 
 Furthermore, this module assumes that you've a dualstack machine. Your IPv4 and
 IPv6 addresses will be automatically set to the `destination_addresses` array

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -83,6 +83,14 @@
 #    ],
 #  }
 #
+# @example create two sides of a session using the public key from the other side
+#  wireguard::interface { 'wg0':
+#    source_addresses => ['2003:4f8:c17:4cf::1', '149.9.255.4'],
+#    public_key       => $facts['wireguard_pubkeys']['nodeB'],
+#    endpoint         => 'nodeB.example.com:53668',
+#    addresses        => [{'Address' => '192.168.123.6/30',},{'Address' => 'fe80::beef:1/64'},],
+#  }
+#
 define wireguard::interface (
   Enum['present', 'absent'] $ensure = 'present',
   Wireguard::Peers $peers = [],


### PR DESCRIPTION
This documents that wg-quick and that systemd-network is optional

I link to the Debian manpages because it's the first thing that came up in a web search, but I'm happy to link elsewhere if there's a better reference.

It also adds an extra example using facts, cross-ref from README. I'm not actually sure that *works*, but it feels like something like that is missing from the examples...
