### PR TITLE
Add table configuration support for both wg-quick and systemd

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -187,6 +187,7 @@ The following parameters are available in the `wireguard::interface` defined typ
 * [`input_interface`](#-wireguard--interface--input_interface)
 * [`manage_firewall`](#-wireguard--interface--manage_firewall)
 * [`dport`](#-wireguard--interface--dport)
+* [`table`](#-wireguard--interface--table)
 * [`firewall_mark`](#-wireguard--interface--firewall_mark)
 * [`source_addresses`](#-wireguard--interface--source_addresses)
 * [`destination_addresses`](#-wireguard--interface--destination_addresses)
@@ -245,6 +246,14 @@ Data type: `Integer[1024, 65000]`
 destination for firewall rules / where our wg instance will listen on. defaults to the last digits from the title
 
 Default value: `Integer(regsubst($title, '^\D+(\d+)$', '\1'))`
+
+##### <a name="-wireguard--interface--table"></a>`table`
+
+Data type: `String[1]`
+
+indicates which routing table to inject the tunnel routes into
+
+Default value: `undef`
 
 ##### <a name="-wireguard--interface--firewall_mark"></a>`firewall_mark`
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -6,6 +6,7 @@
 # @param input_interface ethernet interface where the wireguard packages will enter the system, used for firewall rules
 # @param manage_firewall if true, a ferm rule will be created
 # @param dport destination for firewall rules / where our wg instance will listen on. defaults to the last digits from the title
+# @param table Routing table to add routes to
 # @param firewall_mark netfilter firewall mark to set on outgoing packages from this wireguard interface
 # @param source_addresses an array of ip addresses from where we receive wireguard connections
 # @param destination_addresses array of addresses where the remote peer connects to (our local ips), used for firewalling
@@ -100,6 +101,7 @@ define wireguard::interface (
   Array[Stdlib::IP::Address] $destination_addresses = delete_undef_values([$facts['networking']['ip'], $facts['networking']['ip6'],]),
   String[1] $interface = $title,
   Integer[1024, 65000] $dport = Integer(regsubst($title, '^\D+(\d+)$', '\1')),
+  Optional[String[1]] $table = undef,
   Optional[Integer[0, 4294967295]] $firewall_mark = undef,
   String[1] $input_interface = $facts['networking']['primary'],
   Boolean $manage_firewall = true,
@@ -230,6 +232,7 @@ define wireguard::interface (
         interface     => $interface,
         peers         => $peers + $peer,
         dport         => $dport,
+        table         => $table,
         firewall_mark => $firewall_mark,
         addresses     => $addresses,
         preup_cmds    => $preup_cmds,

--- a/manifests/provider/systemd.pp
+++ b/manifests/provider/systemd.pp
@@ -6,6 +6,7 @@ define wireguard::provider::systemd (
   Enum['present', 'absent'] $ensure = 'present',
   Wireguard::Peers $peers = [],
   Integer[1024, 65000] $dport = Integer(regsubst($title, '^\D+(\d+)$', '\1')),
+  Optional[String[1]] $table = undef,
   Optional[Integer[0,4294967295]] $firewall_mark = undef,
   Array[Hash[String,Variant[Stdlib::IP::Address::V4,Stdlib::IP::Address::V6]]] $addresses = [],
   Optional[String[1]] $description = undef,
@@ -24,6 +25,7 @@ define wireguard::provider::systemd (
     content         => epp("${module_name}/netdev.epp", {
         'interface'     => $interface,
         'dport'         => $dport,
+        'table'         => $table,
         'firewall_mark' => $firewall_mark,
         'description'   => $description,
         'mtu'           => $mtu,

--- a/manifests/provider/wgquick.pp
+++ b/manifests/provider/wgquick.pp
@@ -6,6 +6,7 @@ define wireguard::provider::wgquick (
   Enum['present', 'absent'] $ensure = 'present',
   Wireguard::Peers $peers = [],
   Integer[1024, 65000] $dport = Integer(regsubst($title, '^\D+(\d+)$', '\1')),
+  Optional[String[1]] $table = undef,
   Optional[Integer[0,4294967295]] $firewall_mark = undef,
   Array[Hash[String,Variant[Stdlib::IP::Address::V4,Stdlib::IP::Address::V6]]] $addresses = [],
   Array[String[1]] $preup_cmds = [],
@@ -18,6 +19,7 @@ define wireguard::provider::wgquick (
   $params = {
     'interface'     => $interface,
     'dport'         => $dport,
+    'table'         => $table,
     'firewall_mark' => $firewall_mark,
     'mtu'           => $mtu,
     'peers'         => $peers,

--- a/templates/netdev.epp
+++ b/templates/netdev.epp
@@ -1,5 +1,6 @@
 <%- | String[1] $interface,
       Stdlib::Port $dport,
+      Optional[String[1]] $table,
       Optional[Integer] $firewall_mark,
       Wireguard::Peers $peers,
       Optional[String] $description,
@@ -20,6 +21,9 @@ MTUBytes=<%= $mtu %>
 [WireGuard]
 PrivateKeyFile=/etc/wireguard/<%= $interface %>
 ListenPort=<%= $dport %>
+<% if $table { -%>
+RouteTable=<%= $table %>
+<% } -%>
 <% if $firewall_mark { -%>
 FirewallMark=<%= $firewall_mark %>
 <% } -%>

--- a/templates/wireguard_conf.epp
+++ b/templates/wireguard_conf.epp
@@ -1,6 +1,7 @@
 <%- |
     String[1] $interface,
     Stdlib::Port $dport,
+    Optional[String[1]] $table,
     Optional[Integer] $firewall_mark,
     Wireguard::Peers $peers,
     Array[Hash] $addresses,
@@ -19,6 +20,9 @@
 <% } -%>
 <% } -%>
 ListenPort=<%= $dport %>
+<% if $table { -%>
+Table=<%= $table %>
+<% } -%>
 <% if $firewall_mark { -%>
 FwMark=<%= $firewall_mark %>
 <% } -%>


### PR DESCRIPTION
#### Pull Request (PR) description

Adds "table" parameter to a wireguard interface stanza to be able to set it in the wg-quick/netdev configuration.

NOTE: I've tested this personally only for wg-quick.

#### This Pull Request (PR) fixes the following issues

Fixes #83 