### PR TITLE
persistent_keepalive: Fix regression - paass persistent_keepalive to systemd config

### DIFF
--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -186,9 +186,10 @@ define wireguard::interface (
 
   if $public_key {
     $peer = [{
-        public_key    => $public_key,
-        endpoint      => $endpoint,
-        preshared_key => $preshared_key,
+        public_key           => $public_key,
+        endpoint             => $endpoint,
+        preshared_key        => $preshared_key,
+        persistent_keepalive => $persistent_keepalive,
     }]
   } else {
     $peer = []

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -39,10 +39,25 @@ describe 'wireguard::interface', type: :define do
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.netdev").with_content(%r{PrivateKeyFile=/etc/wireguard/#{title}}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.netdev").with_content(%r{ListenPort=1234}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.netdev").with_content(%r{Endpoint=#{params[:endpoint]}}) }
+        it { is_expected.to contain_file("/etc/systemd/network/#{title}.netdev").with_content(%r{PersistentKeepalive=0}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").without_content(%r{Address}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").without_content(%r{Description}) }
         it { is_expected.to contain_file("/etc/systemd/network/#{title}.network").without_content(%r{MTUBytes}) }
         it { is_expected.not_to contain_ferm__rule("allow_wg_#{title}") }
+      end
+
+      context 'with required params (public_key) and without firewall rules and with PersistentKeepalive=5' do
+        let :params do
+          {
+            public_key: 'blabla==',
+            endpoint: 'wireguard.example.com:1234',
+            manage_firewall: false,
+            persistent_keepalive: 5,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file("/etc/systemd/network/#{title}.netdev").with_content(%r{PersistentKeepalive=5}) }
       end
 
       context 'with required params (peers) and without firewall rules' do


### PR DESCRIPTION

This worked in the past but at some point the inheritance to the epp template broke and persistent_keepalive was always set to 0.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
