### PR TITLE
Make src port for firwalling configureable]

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -214,6 +214,7 @@ The following parameters are available in the `wireguard::interface` defined typ
 * [`postup_cmds`](#-wireguard--interface--postup_cmds)
 * [`predown_cmds`](#-wireguard--interface--predown_cmds)
 * [`postdown_cmds`](#-wireguard--interface--postdown_cmds)
+* [`endpoint_port`](#-wireguard--interface--endpoint_port)
 
 ##### <a name="-wireguard--interface--interface"></a>`interface`
 
@@ -398,6 +399,14 @@ Data type: `Array[String[1]]`
 is an array of commands which should run as preup command (only supported by wgquick)
 
 Default value: `[]`
+
+##### <a name="-wireguard--interface--endpoint_port"></a>`endpoint_port`
+
+Data type: `Optional[Stdlib::Port]`
+
+optional outgoing port from the other endpoint. Will be used for firewalling. If not set, we will try to parse $endpoint
+
+Default value: `undef`
 
 ## Data types
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -24,6 +24,7 @@
 # @param postup_cmds is an array of commands which should run as preup command (only supported by wgquick)
 # @param predown_cmds is an array of commands which should run as preup command (only supported by wgquick)
 # @param postdown_cmds is an array of commands which should run as preup command (only supported by wgquick)
+# @param endpoint_port optional outgoing port from the other endpoint. Will be used for firewalling. If not set, we will try to parse $endpoint
 #
 # @author Tim Meusel <tim@bastelfreak.de>
 # @author Sebastian Rakel <sebastian@devunit.eu>
@@ -116,6 +117,7 @@ define wireguard::interface (
   Array[String[1]] $postup_cmds = [],
   Array[String[1]] $predown_cmds = [],
   Array[String[1]] $postdown_cmds = [],
+  Optional[Stdlib::Port] $endpoint_port = undef,
 ) {
   include wireguard
 
@@ -123,13 +125,14 @@ define wireguard::interface (
     warning('peers or public_key have to been set')
   }
 
+  $_endpoint_port = if $endpoint_port {
+    $endpoint_port
+  } elsif ($endpoint and $endpoint =~ /:(\d+)$/) {
+    Integer($1)
+  } else {
+    undef
+  }
   if $manage_firewall {
-    # ToDo: It would be nice if this would be a parameter
-    if $endpoint =~  /:(\d+)$/ {
-      $endpoint_port = Integer($1)
-    } else {
-      $endpoint_port = undef
-    }
     $source_addresses.each |$index1, $saddr| {
       if $saddr =~ Stdlib::IP::Address::V4 {
         if empty($destination_addresses) {
@@ -137,7 +140,7 @@ define wireguard::interface (
             action  => 'accept',
             comment => "Allow traffic from interface ${input_interface} from IP ${saddr} for wireguard tunnel ${interface}",
             dport   => $dport,
-            sport   => $endpoint_port,
+            sport   => $_endpoint_port,
             proto   => 'udp',
             saddr   => $saddr,
             iifname => $input_interface,
@@ -146,7 +149,7 @@ define wireguard::interface (
           nftables::simplerule { "allow_out_wg_${interface}-${index1}":
             action  => 'accept',
             comment => "Allow traffic out interface ${input_interface} to IP ${saddr} for wireguard tunnel ${interface}",
-            dport   => $endpoint_port,
+            dport   => $_endpoint_port,
             sport   => $dport,
             proto   => 'udp',
             daddr   => $saddr,
@@ -161,7 +164,7 @@ define wireguard::interface (
                 action  => 'accept',
                 comment => "Allow traffic from interface ${input_interface} from IP ${saddr} for wireguard tunnel ${interface}",
                 dport   => $dport,
-                sport   => $endpoint_port,
+                sport   => $_endpoint_port,
                 proto   => 'udp',
                 daddr   => $_daddr,
                 saddr   => $saddr,
@@ -171,7 +174,7 @@ define wireguard::interface (
               nftables::simplerule { "allow_out_wg_${interface}-${index1}${index2}":
                 action  => 'accept',
                 comment => "Allow traffic out interface ${input_interface} to IP ${saddr} for wireguard tunnel ${interface}",
-                dport   => $endpoint_port,
+                dport   => $_endpoint_port,
                 sport   => $dport,
                 proto   => 'udp',
                 daddr   => $saddr,
@@ -197,7 +200,7 @@ define wireguard::interface (
           nftables::simplerule { "allow_out_wg_${interface}-${index1}":
             action  => 'accept',
             comment => "Allow traffic out interface ${input_interface} to IP ${saddr} for wireguard tunnel ${interface}",
-            dport   => $endpoint_port,
+            dport   => $_endpoint_port,
             sport   => $dport,
             proto   => 'udp',
             daddr   => $saddr,
@@ -221,7 +224,7 @@ define wireguard::interface (
               nftables::simplerule { "allow_out_wg_${interface}-${index1}${index2}":
                 action  => 'accept',
                 comment => "Allow traffic out interface ${input_interface} to IP ${saddr} for wireguard tunnel ${interface}",
-                dport   => $endpoint_port,
+                dport   => $_endpoint_port,
                 sport   => $dport,
                 proto   => 'udp',
                 daddr   => $saddr,

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -11,16 +11,6 @@ describe 'wireguard::interface', type: :define do
         os_facts
       end
 
-      context 'with only default values and manage_firewall=true it wont work' do
-        let :params do
-          {
-            manage_firewall: true
-          }
-        end
-
-        it { is_expected.not_to compile }
-      end
-
       context 'with only default values and manage_firewall=false it wont work' do
         let :params do
           {
@@ -551,27 +541,79 @@ describe 'wireguard::interface', type: :define do
       # The param is optional, in case you want to create a passive endpoint for clients with dynamic ip addresses
       # In those cases we still need to create firewall rules, but without src port for incoming packets / the dst port
       # To make this all a bit easier, we also added a new parameter, $endpoint_port, which takes precedence over parsing $endpoint
-      context '' do
-        let :pre_condition do
-          'class {"systemd":
-            manage_networkd => true
-          }'
-        end
-        let :params do
-          {
-            public_key: 'blabla==',
-            manage_firewall: true,
-            destination_addresses: [],
-            addresses: [{ 'Address' => '192.0.2.1/24' }],
-            source_addresses: ['fe80::1', '127.0.0.1'],
-          }
+      # dport for incoming / sport for outgoing packets is parsed from $title.
+      context 'verifies src port for incoming packets / the dst port for outgoing packets' do
+        # check that catalog compiles and we create rules, but without the port
+        context 'without endpoint_port without endpoint' do
+          let :pre_condition do
+            'class {"systemd":
+              manage_networkd => true
+            }'
+          end
+          let :params do
+            {
+              public_key: 'blabla==',
+              manage_firewall: true,
+              destination_addresses: [],
+              addresses: [{ 'Address' => '192.0.2.1/24' }],
+              source_addresses: ['fe80::1', '127.0.0.1'],
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_nftables__simplerule('allow_in_wg_as1234-0').without_sport.with_dport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_in_wg_as1234-1').without_sport.with_dport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_out_wg_as1234-0').without_dport.with_sport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_out_wg_as1234-1').without_dport.with_sport(1234) }
         end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_nftables__simplerule('allow_in_wg_as1234-0').without_sport.with_dport(1234) }
-        it { is_expected.to contain_nftables__simplerule('allow_in_wg_as1234-1').without_sport.with_dport(1234) }
-        it { is_expected.to contain_nftables__simplerule('allow_out_wg_as1234-0').without_dport.with_sport(1234) }
-        it { is_expected.to contain_nftables__simplerule('allow_out_wg_as1234-1').without_dport.with_sport(1234) }
+        context 'with endpoint_port' do
+          let :pre_condition do
+            'class {"systemd":
+              manage_networkd => true
+            }'
+          end
+          let :params do
+            {
+              public_key: 'blabla==',
+              manage_firewall: true,
+              destination_addresses: [],
+              addresses: [{ 'Address' => '192.0.2.1/24' }],
+              source_addresses: ['fe80::1', '127.0.0.1'],
+              endpoint_port: 5678,
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_nftables__simplerule('allow_in_wg_as1234-0').with_sport(5678).with_dport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_in_wg_as1234-1').with_sport(5678).with_dport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_out_wg_as1234-0').with_dport(5678).with_sport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_out_wg_as1234-1').with_dport(5678).with_sport(1234) }
+        end
+
+        context 'with endpoint' do
+          let :pre_condition do
+            'class {"systemd":
+              manage_networkd => true
+            }'
+          end
+          let :params do
+            {
+              public_key: 'blabla==',
+              manage_firewall: true,
+              destination_addresses: [],
+              addresses: [{ 'Address' => '192.0.2.1/24' }],
+              source_addresses: ['fe80::1', '127.0.0.1'],
+              endpoint: 'foo.example.com:5678',
+            }
+          end
+
+          it { is_expected.to compile }
+          it { is_expected.to contain_nftables__simplerule('allow_in_wg_as1234-0').with_sport(5678).with_dport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_in_wg_as1234-1').with_sport(5678).with_dport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_out_wg_as1234-0').with_dport(5678).with_sport(1234) }
+          it { is_expected.to contain_nftables__simplerule('allow_out_wg_as1234-1').with_dport(5678).with_sport(1234) }
+        end
       end
     end
   end


### PR DESCRIPTION
Usually we parse the src port for incoming packets / the dst port for outgoing packets from the $endpoint param The param is optional, in case you want to create a passive endpoint for clients with dynamic ip addresses In those cases we still need to create firewall rules, but without src port for incoming packets / the dst port To make this all a bit easier, we also added a new parameter, $endpoint_port, which takes precedence over parsing $endpoint.

Previously the catalog compilation failed with:
```
Evaluation Error: Left match operand must result in a String value. Got an Undef Value.
```

Because of: `if $endpoint =~  /:(\d+)$/ {`

https://github.com/voxpupuli/puppet-wireguard/pull/103 verifies that the current code is broken.

Thew new code adds a safeguard to check if $endpoint is set. we also add a new parameter in case we want to explicitly set the port.