### PR TITLE
Remove Description from NetDev and add friendly_name

### DIFF
--- a/templates/netdev.epp
+++ b/templates/netdev.epp
@@ -31,9 +31,6 @@ FirewallMark=<%= $firewall_mark %>
 <% $peers.each |$peer| { -%>
 
 [WireGuardPeer]
-<% if $peer['description'] { -%>
-Description=<%= $peer['description'] %>
-<% } -%>
 PublicKey=<%= $peer['public_key'] %>
 <% if $peer['preshared_key'] { -%>
 PresharedKey=<%= $peer['preshared_key'] %>

--- a/templates/wireguard_conf.epp
+++ b/templates/wireguard_conf.epp
@@ -46,10 +46,11 @@ MTU=<%= $mtu %>
 
 <% $peers.each |$peer| { -%>
 
-<% if $peer['description'] { -%>
-# <%= $peer['description'] %>
-<% } -%>
 [Peer]
+<% if $peer['description'] { -%>
+# friendly_name = <%= $peer['description'] %>
+Description=
+<% } -%>
 PublicKey=<%= $peer['public_key'] %>
 <% if $peer['endpoint'] { -%>
 Endpoint=<%= $peer['endpoint'] %>


### PR DESCRIPTION
Description is not a supported field from systemd netdev (https://www.freedesktop.org/software/systemd/man/latest/systemd.netdev.html\#%5BWireGuardPeer%5D%20Section%20Options). friendly_name makes the Wireguard config compatible with prometheus_wireguard_exporter

Fix #127
Fix #123

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
