### PR TITLE
fix: Move addresses inside [Interface] section of wg-quick template

### DIFF
--- a/templates/wireguard_conf.epp
+++ b/templates/wireguard_conf.epp
@@ -13,9 +13,9 @@
     Optional[Integer[1280, 9000]] $mtu = undef,
 | -%>
 # THIS FILE IS MANAGED BY PUPPET
-<% $addresses.each |$address| { -%>
 
 [Interface]
+<% $addresses.each |$address| { -%>
 <% $address.each |$key, $value| { -%>
 <%= $key %>=<%= $value %>
 <% } -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Move the `$addresses.each` loop inside the `[Interface]` section of the wg-quick configuration.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Fixes #134
-->
